### PR TITLE
storage key generation & sumarize output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 /db/
 **/*.rs.bk
 debug_all_key.txt
+plan.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ rust:
   - stable
   - nightly
 
+before_install:
+  - sudo apt-get -y update
+  - sudo apt-get install -y
+
 # Yes, use nightly as default
 matrix:
   allow_failures:
@@ -14,5 +18,7 @@ jobs:
   include:
     - stage: "Test"
       script: cargo test --verbose --all
+    - stage: "Test"
+      script: test.sh
     - stage: "Build"
       script: cargo build --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,13 @@
 language: rust
-rust:
-  - stable
-  - nightly
+rust: nightly
 
 before_install:
   - sudo apt-get -y update
-  - sudo apt-get install -y
-
-# Yes, use nightly as default
-matrix:
-  allow_failures:
-    - rust: stable
-  fast_finish: true
-cache: cargo
+  - sudo apt-get install -y jq cmake pkg-config libssl-dev git gcc build-essential clang libclang-dev
 
 jobs:
   include:
-    - stage: "Test"
-      script: cargo test --verbose --all
-    - stage: "Test"
-      script: test.sh
-    - stage: "Build"
+    - stage: Build
       script: cargo build --verbose --all
+    - stage: Cli Test
+      script: ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: rust
+rust:
+  - stable
+  - nightly
+
+# Yes, use nightly as default
+matrix:
+  allow_failures:
+    - rust: stable
+  fast_finish: true
+cache: cargo
+
+jobs:
+  include:
+    - stage: "Test"
+      script: cargo test --verbose --all
+    - stage: "Build"
+      script: cargo build --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,20 @@ hash-db = "0.15.2"
 # current version is 0.21 but build fail
 # Issue open at https://github.com/paritytech/trie/issues/95
 trie-db = "0.19.2"
-trie = { package="sp-trie", git = 'https://github.com/yanganto/substrate.git', branch='expose-hash-roots' }
-sp-std = { package="sp-std", git = 'https://github.com/yanganto/substrate.git', branch='expose-hash-roots' }
-sp-core = { package="sp-core", git = 'https://github.com/yanganto/substrate.git', branch='expose-hash-roots' }
+sp-trie = { package="sp-trie", git = 'https://github.com/yanganto/substrate.git', branch='ssi', default-features = false }
+sp-std = { package="sp-std", git = 'https://github.com/yanganto/substrate.git', branch='ssi', default-features = false }
+sp-core = { package="sp-core", git = 'https://github.com/yanganto/substrate.git', branch='ssi', default-features = false  }
 
 log = "0.4.8"
 clap = "2.33.1"
 hex = "0.4.2"
 failure = "0.1.8"
 failure_derive ="0.1.8"
+
+[features]
+default = ["std"]
+std = [
+    "sp-std/std",
+    "sp-core/std",
+    "sp-trie/std",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ hash-db = "0.15.2"
 trie-db = "0.19.2"
 trie = { package="sp-trie", git = 'https://github.com/yanganto/substrate.git', branch='expose-hash-roots' }
 sp-std = { package="sp-std", git = 'https://github.com/yanganto/substrate.git', branch='expose-hash-roots' }
+sp-core = { package="sp-core", git = 'https://github.com/yanganto/substrate.git', branch='expose-hash-roots' }
+
 log = "0.4.8"
 clap = "2.33.1"
 hex = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -13,14 +13,32 @@ The data will show in the node or in the nodes of a subtrie.
 
 ### Sample Commands
 
-Here is an example help you can use in query the data in Rocks DB with System pallet Account storage at block #50
+Here are examples help you can use in query the data of `Account` field in `System` pallet in Rocks DB at block #50
+
 ```
 ssi -r 0x3b559d574c4a9f13e55d0256655f0f71a70a703766226f1080f80022e39c057d -k 26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9 ./db
 ```
-Also you can use following command to inspect the data all nodes in the subtrie at block #5
+
+or 
+
+```
+ssi -r 0x3b559d574c4a9f13e55d0256655f0f71a70a703766226f1080f80022e39c057d -P System -F Account ./db -s
+```
+
+
+Also you can use following command to inspect the data of `System` pallet in Rocks DB at block #5
+
 ```
 ssi -r 0x940a55c41ce61b2d771e82f8a6c6f4939a712a644502f5efa7c59afea0a3a67e -k 26aa394eea5630e07c48ae0c9558cef7 ./db
 ```
+
+or
+
+```
+ssi -r 0x940a55c41ce61b2d771e82f8a6c6f4939a712a644502f5efa7c59afea0a3a67e -P System ./db
+```
+
+Besides, you can exactly insepc
 
 ### Options
 Here is the required parameters to use this tool.
@@ -28,16 +46,20 @@ Here is the required parameters to use this tool.
 ssi --root-hash <root hash> --storage-key <storage key> <db path>
 ``` 
 
+Following infomation is required:
 - `db path`: the path to the rocksdb used to storage data of the chain build in Substrate
 - `root hash`: the root hash for trie node in the chain build in Substrate
-- `storage key`: the storage key used in substrate runtime
+- storage key info, it can be provide by `storage key` or `pallet`, `field`, `twox 64 concat`, `black2 128 concat`, `twox 64 concat 2nd`, `black2 128 concat 2nd`
+  - `storage key`: directly set the storage key used in substrate runtime
+  - other options: these options are infomation from substrate pallet, and will be used to generate the storage key  
 
 There are still some optional options to help you inspect the database.
-- `-e`, exactly mode, will no get the node in subtrie, only the data from the node exactly match the storage key.
+- `-e`, exactly mode, this mode will no get the node in subtrie, only the data from the node exactly match the storage key.
+- `-s`, sumary mode, this mode will show the data sumary of a node, if you only take care about data chaging without the exactly meaning.
 - `-l <trace/debug/info/warn/error>`, show logs with different level
   - `info` level: the node type of storage key
-  - `debug` level: the path to trace the trie
-  - `trace` level: use for developing
+  - `debug` level: the operation about path to trace the trie
+  - `trace` level: the operation in DB layer for development
   - `warn` level: show the error if the database incorrect or damage or some node is incorrect
   - `error` level: show the error of this tool
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # SSI
+
+
+[![Build Status](https://travis-ci.com/yanganto/ssi.svg?branch=master)](https://travis-ci.com/yanganto/ssi)
+
 **S**ubstrate **S**torage **I**nspector is a tool to get the data in the DB of substrate base block chain.
 
 ## Usage
@@ -19,8 +23,16 @@ ssi -r 0x940a55c41ce61b2d771e82f8a6c6f4939a712a644502f5efa7c59afea0a3a67e -k 26a
 ```
 
 ### Options
+Here is the required parameters to use this tool.
+``` 
+ssi --root-hash <root hash> --storage-key <storage key> <db path>
+``` 
 
-There are still some options to help you inspect the database.
+- `db path`: the path to the rocksdb used to storage data of the chain build in Substrate
+- `root hash`: the root hash for trie node in the chain build in Substrate
+- `storage key`: the storage key used in substrate runtime
+
+There are still some optional options to help you inspect the database.
 - `-e`, exactly mode, will no get the node in subtrie, only the data from the node exactly match the storage key.
 - `-l <trace/debug/info/warn/error>`, show logs with different level
   - `info` level: the node type of storage key

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,10 +137,10 @@ where
                 .help("The identity key used for generate double map storage key you want to inspect"),
         )
         .arg(
-            Arg::with_name("summary output")
+            Arg::with_name("summarize output")
                 .short("s")
-                .long("summary")
-                .help("summary the data of node to \"Data hash:{twox_hash_of_data}, length: {length}, Leaf: {true/false}\""),
+                .long("summarize")
+                .help("summarize the data of node to \"hash:{twox_hash_of_data}, length: {length}, Leaf: {true/false}\""),
         )
         .arg(
             Arg::with_name("db path")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,7 +66,7 @@ where
                 .long("pallet")
                 .takes_value(true)
 				.conflicts_with("storage key")
-                .help("The pallet use for generate storage key you want to inspect, ex: System"),
+                .help("The pallet name used for generate storage key you want to inspect, ex: System"),
         )
         .arg(
             Arg::with_name("field")
@@ -74,7 +74,7 @@ where
                 .long("field")
                 .takes_value(true)
 				.conflicts_with("storage key")
-                .help("The storage field use for generate storage key you want to inspect, ex: Account"),
+                .help("The storage field name used for generate storage key you want to inspect, ex: Account"),
         )
         .arg(
             Arg::with_name("twox 64 concat")
@@ -83,7 +83,8 @@ where
                 .takes_value(true)
 				.conflicts_with("storage key")
 				.conflicts_with("black2 128 concat")
-                .help("The twox 64 hash and concat the key use for generate storage key you want to inspect"),
+				.conflicts_with("identity")
+                .help("The twox 64 hash and concated the key used for generate storage key you want to inspect"),
         )
         .arg(
             Arg::with_name("black2 128 concat")
@@ -92,7 +93,18 @@ where
                 .takes_value(true)
 				.conflicts_with("storage key")
 				.conflicts_with("twox 64 concat")
-                .help("The black2 128 hash and concat the 2nd key of double map use for generate storage key you want to inspect"),
+				.conflicts_with("identity")
+                .help("The black2 128 hash and concated the key used for generate storage key you want to inspect"),
+        )
+        .arg(
+            Arg::with_name("identity")
+                .short("I")
+                .long("id")
+                .takes_value(true)
+				.conflicts_with("storage key")
+				.conflicts_with("twox 64 concat")
+				.conflicts_with("black2 128 concat")
+                .help("The identity key used for generate storage key you want to inspect"),
         )
         .arg(
             Arg::with_name("twox 64 concat 2nd")
@@ -101,7 +113,8 @@ where
                 .takes_value(true)
 				.conflicts_with("storage key")
 				.conflicts_with("black2 128 concat 2nd")
-                .help("The twox 64 hash and concat the 2nd key use of double map for generate storage key you want to inspect"),
+				.conflicts_with("identity 2nd")
+                .help("The twox 64 hash and concated the 2nd key used for generate double map storage key you want to inspect"),
         )
         .arg(
             Arg::with_name("black2 128 concat 2nd")
@@ -110,7 +123,18 @@ where
                 .takes_value(true)
 				.conflicts_with("storage key")
 				.conflicts_with("twox 64 concat 2nd")
-                .help("The black2 128 hash and concat the key use for generate storage key you want to inspect"),
+				.conflicts_with("identity 2nd")
+                .help("The black2 128 hash and concat the key use for generate double map storage key you want to inspect"),
+        )
+        .arg(
+            Arg::with_name("identity 2nd")
+                .short("i")
+                .long("id-2")
+                .takes_value(true)
+				.conflicts_with("storage key")
+				.conflicts_with("twox 64 concat 2nd")
+				.conflicts_with("black2 128 concat 2nd")
+                .help("The identity key used for generate double map storage key you want to inspect"),
         )
         .arg(
             Arg::with_name("summary output")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 // Comand Line Handle
 
-use clap::{App, Arg, ArgMatches};
+pub use clap::ArgMatches;
+use clap::{App, Arg};
 use std::ffi::OsString;
 
 // use crate::character_map::SYMBOL_MAP;
@@ -51,14 +52,77 @@ where
                 .short("k")
                 .long("storage-key")
                 .takes_value(true)
+				.conflicts_with("pallet")
+				.conflicts_with("field")
+				.conflicts_with("twox 64 concat")
+				.conflicts_with("black2 128 concat")
+				.conflicts_with("twox 64 concat 2nd")
+				.conflicts_with("black2 128 concat 2nd")
                 .help("The storage key you want to inspect, it is okay to use only prefix part of storage key, ex: 6aa394eea5630e07c48ae0c9558cef7"),
+        )
+        .arg(
+            Arg::with_name("pallet")
+                .short("P")
+                .long("pallet")
+                .takes_value(true)
+				.conflicts_with("storage key")
+                .help("The pallet use for generate storage key you want to inspect, ex: System"),
+        )
+        .arg(
+            Arg::with_name("field")
+                .short("F")
+                .long("field")
+                .takes_value(true)
+				.conflicts_with("storage key")
+                .help("The storage field use for generate storage key you want to inspect, ex: Account"),
+        )
+        .arg(
+            Arg::with_name("twox 64 concat")
+                .short("T")
+                .long("twox-64-cat")
+                .takes_value(true)
+				.conflicts_with("storage key")
+				.conflicts_with("black2 128 concat")
+                .help("The twox 64 hash and concat the key use for generate storage key you want to inspect"),
+        )
+        .arg(
+            Arg::with_name("black2 128 concat")
+                .short("B")
+                .long("blk2-128-cat")
+                .takes_value(true)
+				.conflicts_with("storage key")
+				.conflicts_with("twox 64 concat")
+                .help("The black2 128 hash and concat the 2nd key of double map use for generate storage key you want to inspect"),
+        )
+        .arg(
+            Arg::with_name("twox 64 concat 2nd")
+                .short("t")
+                .long("twox-64-cat-2")
+                .takes_value(true)
+				.conflicts_with("storage key")
+				.conflicts_with("black2 128 concat 2nd")
+                .help("The twox 64 hash and concat the 2nd key use of double map for generate storage key you want to inspect"),
+        )
+        .arg(
+            Arg::with_name("black2 128 concat 2nd")
+                .short("b")
+                .long("blk2-128-cat-2")
+                .takes_value(true)
+				.conflicts_with("storage key")
+				.conflicts_with("twox 64 concat 2nd")
+                .help("The black2 128 hash and concat the key use for generate storage key you want to inspect"),
+        )
+        .arg(
+            Arg::with_name("summary output")
+                .short("s")
+                .long("summary")
+                .help("summary the data of node to \"Data hash:{twox_hash_of_data}, length: {length}, Leaf: {true/false}\""),
         )
         .arg(
             Arg::with_name("db path")
                 .help("the db path to Rocks DB")
                 .index(1)
                 .requires("root hash")
-                .requires("storage key")
                 .required(true),
         )
         .get_matches_from(itr)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,7 +2,7 @@
 /// implement import trait to read the storage
 use hash_db::{AsHashDB, HashDB, HashDBRef, Hasher as HashDBHasher, Prefix};
 use rocksdb::{IteratorMode, Options, DB};
-use trie::node_codec::NodeCodec;
+use sp_trie::node_codec::NodeCodec;
 use trie_db::TrieLayout;
 
 use crate::logger::{debug, trace};

--- a/test.sh
+++ b/test.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
-
 set -eux
-
-
 source ~/.cargo/env
-
-rustup --version
-cargo --version
-rustc --version
 
 echo -e "Test SSI output is complied with JSON format ..."
 cargo run -- -r 0x3b559d574c4a9f13e55d0256655f0f71a70a703766226f1080f80022e39c057d -P System -F Account  ./db  -s | jq

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eux
+
+
+source ~/.cargo/env
+
+rustup --version
+cargo --version
+rustc --version
+
+echo -e "Test SSI output is complied with JSON format ..."
+cargo run -- -r 0x3b559d574c4a9f13e55d0256655f0f71a70a703766226f1080f80022e39c057d -P System -F Account  ./db  -s | jq
+echo -e "Test SSI sumarized output is complied with JSON format ..."
+cargo run -- -r 0x3b559d574c4a9f13e55d0256655f0f71a70a703766226f1080f80022e39c057d -P System -F Account -s ./db  -s | jq
+echo -e "\e[0;32m +------------+ \n\e[0;32m  | JSON Format Pass | \n\e[0;32m  +------------+ \e[0m"
+


### PR DESCRIPTION
- implement the storage key generation with options: `pallet`, `field`, `twox 64 concat`, `black2 128 concat`, `twox 64 concat 2nd`, `black2 128 concat 2nd`, `identiy` and `identiy 2nd`
- implement the data summary as JSON format with option `summary`
- handle following errors:
  - nonsexist path error
  - conflict in options about storage key generation
- init Travis CI
- init test
  - test output comply with JSON format
  - test sumarized output comply with JSON format
- fix dependency issue